### PR TITLE
fix: Fixes an issue with strings that starts with numbers

### DIFF
--- a/lib/pdf417/number_compactor.ex
+++ b/lib/pdf417/number_compactor.ex
@@ -9,7 +9,7 @@ defmodule PDF417.NumberCompactor do
   end
 
   def compactable?(part) do
-    String.length(part) > 13 && Integer.parse(part) != :error
+    String.length(part) > 13 && String.match?(part, ~r/^\d+$/)
   end
 
   def codeword, do: 902

--- a/test/number_compactor_test.exs
+++ b/test/number_compactor_test.exs
@@ -19,8 +19,16 @@ defmodule PDF417.NumberCompactorTest do
       assert NumberCompactor.compactable?("12345678912345")
     end
 
-    test "returns false for strings" do
+    test "returns false for short strings" do
       refute NumberCompactor.compactable?("asdf")
+    end
+
+    test "returns false for long strings" do
+      refute NumberCompactor.compactable?("stringgreaterthanthirteencharacters")
+    end
+
+    test "returns false for strings that does not represent a number" do
+      refute NumberCompactor.compactable?("123abcdefghijkl")
     end
 
     test "returns false for short numbers" do


### PR DESCRIPTION
Hi,

When using `PDF417.encode` or `PDF417.encode_to_base64`  with a string that starts with a number and is greater than 13 digits, the `NumberCompactor.compactable?` is returning `true` due to `Integer.parse(part)` returning an output like `{number, rest of string}` 

i.e a string like `74cLlWZPjVWX02` when calling `Integer.parse("74cLlWZPjVWX02")` it returns `{74, "cLlWZPjVWX02"}`  and then later when using `String.to_integer()` in the `def compact(part)` function, it raises an error `1st argument: not a textual representation of an integer` because it is not a string integer representation.

Instead of using `Integer.parse`, we can use a regex to only accept strings with numbers (string integer representation)

