### PR TITLE
[LOTC-2294] Fix warning for Range deprecation in elixir 1.18

### DIFF
--- a/.github/workflows/pdf417.yml
+++ b/.github/workflows/pdf417.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Retrieve Cached Dependencies
         id: mix-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ./deps

--- a/lib/pdf417/error_correction.ex
+++ b/lib/pdf417/error_correction.ex
@@ -13,7 +13,7 @@ defmodule PDF417.ErrorCorrection do
       t1 = rem(codeword + List.last(int_error_cw), 929)
 
       int_error_cw =
-        (length(int_error_cw) - 1)..1
+        Range.new(length(int_error_cw) - 1, 1, -1)
         |> Enum.reduce(int_error_cw, fn j, acc ->
           t2 = rem(t1 * Enum.at(coefficients, j), 929)
           t3 = 929 - t2

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule PDF417.MixProject do
   use Mix.Project
 
-  @version "0.1.0"
+  @version "0.1.1"
   @source_url "https://github.com/jackpocket/pdf417-elixir"
 
   def project do


### PR DESCRIPTION
Range.new/2 was deprecated in elixir 1.18.  FIST was recently updated to 1.18 and we are now seeing a warning due to that usage.  This PR just updates the code to call Range.new/3 instead.

Warning is...

```
warning: Range.new/2 and first..last default to a step of -1 when last < first. Use Range.new(first, last, -1) or first..last//-1, or pass 1 if that was your intention
  (pdf417 0.2.0) lib/pdf417/error_correction.ex:16: anonymous fn/3 in PDF417.ErrorCorrection.correction_codewords/2
  (elixir 1.18.3) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3
  (pdf417 0.2.0) lib/pdf417/error_correction.ex:12: PDF417.ErrorCorrection.correction_codewords/2
  (pdf417 0.2.0) lib/pdf417/high_level_encoder.ex:40: PDF417.HighLevelEncoder.error_correction/2
  (pdf417 0.2.0) lib/pdf417/high_level_encoder.ex:16: PDF417.HighLevelEncoder.encode/1
  (pdf417 0.2.0) lib/pdf417.ex:23: PDF417.encode/2
  (fist 0.1.0) lib/fist_web/helpers.ex:18: FISTWeb.Helpers.base64_front_barcode_image/1
  (fist 0.1.0) lib/fist_web/live/redeem_ticket_barcodes_live/redeem_ticket_barcodes_live.html.heex:88: anonymous fn/2 in FISTWeb.RedeemTicketBarcodesLive.render/1
  (phoenix_live_view 1.1.16) lib/phoenix_live_view/diff.ex:420: Phoenix.LiveView.Diff.traverse/6
  (phoenix_live_view 1.1.16) lib/phoenix_live_view/diff.ex:609: anonymous fn/3 in Phoenix.LiveView.Diff.traverse_dynamic/6
  (elixir 1.18.3) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3
  (phoenix_live_view 1.1.16) lib/phoenix_live_view/diff.ex:419: Phoenix.LiveView.Diff.traverse/6
  (phoenix_live_view 1.1.16) lib/phoenix_live_view/diff.ex:609: anonymous fn/3 in Phoenix.LiveView.Diff.traverse_dynamic/6
  (elixir 1.18.3) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3
  (phoenix_live_view 1.1.16) lib/phoenix_live_view/diff.ex:398: Phoenix.LiveView.Diff.traverse/6
  (phoenix_live_view 1.1.16) lib/phoenix_live_view/diff.ex:609: anonymous fn/3 in Phoenix.LiveView.Diff.traverse_dynamic/6
  (elixir 1.18.3) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3

```